### PR TITLE
Remove dependency on self to allow installation

### DIFF
--- a/sexp_path.gemspec
+++ b/sexp_path.gemspec
@@ -62,20 +62,17 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<sexp_path>, [">= 0"])
       s.add_development_dependency(%q<ruby_parser>, ["~> 3.1"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_runtime_dependency(%q<sexp_processor>, ["~> 3.0"])
       s.add_development_dependency(%q<ruby_parser>, ["~> 2.0"])
     else
-      s.add_dependency(%q<sexp_path>, [">= 0"])
       s.add_dependency(%q<ruby_parser>, ["~> 3.1"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<sexp_processor>, ["~> 3.0"])
       s.add_dependency(%q<ruby_parser>, ["~> 2.0"])
     end
   else
-    s.add_dependency(%q<sexp_path>, [">= 0"])
     s.add_dependency(%q<ruby_parser>, ["~> 3.1"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<sexp_processor>, ["~> 3.0"])


### PR DESCRIPTION
This is a fix for the same issue as #11 - allows installation of the gem using newer rubygems. It isn't a good idea to use the Gemfile for dependencies, that's what the gemspec is for in gems. I tested this on ree 1.8.7, 1.9.3, 2.0 and rbx-2, and found that the test test_finding_empty_test_methods is failing. It was failing before this change, so I'm not sure what's up there.
